### PR TITLE
Use ExtendedWatchEventModifier.FILE_TREE when supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Travis CI](https://travis-ci.org/gmethvin/directory-watcher.svg?branch=master)](https://travis-ci.org/gmethvin/directory-watcher) [![Maven](https://img.shields.io/maven-central/v/io.methvin/directory-watcher.svg)](http://mvnrepository.com/artifact/io.methvin/directory-watcher)
-
 # Directory Watcher
+
+[![Travis CI](https://travis-ci.org/gmethvin/directory-watcher.svg?branch=master)](https://travis-ci.org/gmethvin/directory-watcher) [![AppVeyor CI](https://ci.appveyor.com/api/projects/status/j8u639uf2iovtf15/branch/master?svg=true)](https://ci.appveyor.com/project/gmethvin/directory-watcher/branch/master) [![Maven](https://img.shields.io/maven-central/v/io.methvin/directory-watcher.svg)](http://mvnrepository.com/artifact/io.methvin/directory-watcher)
 
 A recursive directory watcher utility for JDK 8+, along with a native OS X implementation of the WatchService.
 
@@ -70,7 +70,9 @@ public class DirectoryWatchingUtility {
 
 ## Implementation differences
 
-The Mac OS X implementation returns the full absolute path of the file in its change notifications, so the returned path does not need to be resolved against the `WatchKey`. The `DirectoryWatcher` abstracts away the details of that though.
+The Mac OS X implementation returns the full absolute path of the file in its change notifications, so the returned path does not need to be resolved against the `WatchKey`. The `DirectoryWatcher` abstracts away the details of that.
+
+The Mac OS X WatchService watches recursively by default. On platforms that support it (Windows), the `DirectoryWatcher` utility uses `ExtendedWatchEventModifier.FILE_TREE` to watch recursively. On other platforms (e.g. Linux) it will watch the current directory and register a new `WatchKey` for subdirectories as they are added.
 
 ## Credits
 

--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,9 @@ lazy val `directory-watcher` = (project in file("."))
     )
   )
 
+fork in Test := true
+javaOptions in Test += "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
+
 publishMavenStyle := true
 publishTo := Some(
   if (isSnapshot.value)

--- a/src/main/java/io/methvin/watcher/PathUtils.java
+++ b/src/main/java/io/methvin/watcher/PathUtils.java
@@ -42,7 +42,7 @@ public class PathUtils {
         if (!f.exists()) {
           return null;
         }
-        return Files.hash(file.toFile(), HASH_FUNCTION);
+        return Files.asByteSource(file.toFile()).hash(HASH_FUNCTION);
       } else {
         return HASH_FUNCTION.newHasher().putString(file.toString(), Charsets.UTF_8).hash();
       }

--- a/src/test/java/io/methvin/watchservice/DirectoryWatcherTest.java
+++ b/src/test/java/io/methvin/watchservice/DirectoryWatcherTest.java
@@ -129,7 +129,7 @@ public class DirectoryWatcherTest {
     watcher.close();
 
     // Let's see if everything works!
-    assertEquals(actions.size(), events.size());
+    assertEquals("actions.size", actions.size(), events.size());
     //
     // Now we make a map of the events keyed by the path. The order in which we
     // play the filesystem actions is not necessarily the order in which the events are
@@ -139,30 +139,30 @@ public class DirectoryWatcherTest {
     // the order of the played actions to match the order of the events emitted.
     //
     List<WatchEvent.Kind<?>> one = events.get("one.txt");
-    assertEquals(2, one.size());
+    assertEquals("one.size", 2, one.size());
     assertEquals(one.get(0), actions.get(0).kind);
     assertEquals(one.get(1), actions.get(5).kind);
 
     List<WatchEvent.Kind<?>> two = events.get("two.txt");
-    assertEquals(1, two.size());
+    assertEquals("two.size", 1, two.size());
     assertEquals(two.get(0), actions.get(1).kind);
 
     List<WatchEvent.Kind<?>> three = events.get("three.txt");
-    assertEquals(3, three.size());
+    assertEquals("three.size", 3, three.size());
     assertEquals(three.get(0), actions.get(2).kind);
     assertEquals(three.get(1), actions.get(3).kind);
     assertEquals(three.get(2), actions.get(4).kind);
 
     List<WatchEvent.Kind<?>> testDir = events.get("testDir");
-    assertEquals(1, testDir.size());
+    assertEquals("testDir.size", 1, testDir.size());
     assertEquals(testDir.get(0), actions.get(6).kind);
 
     List<WatchEvent.Kind<?>> four = events.get("testDir/file1InDir.txt");
-    assertEquals(1, four.size());
+    assertEquals("four.size", 1, four.size());
     assertEquals(three.get(0), actions.get(7).kind);
 
     List<WatchEvent.Kind<?>> five = events.get("testDir/file2InDir.txt");
-    assertEquals(2, five.size());
+    assertEquals("five.size", 2, five.size());
     assertEquals(three.get(0), actions.get(8).kind);
     assertEquals(three.get(1), actions.get(9).kind);
 
@@ -200,8 +200,9 @@ public class DirectoryWatcherTest {
     }
 
     void updateActions(Path path, WatchEvent.Kind<?> kind) {
-      System.out.println(kind + " ----> " + path);
-      events.put(directory.relativize(path).toString(), kind);
+      String relativePath = directory.relativize(path).toString().replace('\\', '/');
+      System.out.println(kind + " ----> " + relativePath);
+      events.put(relativePath, kind);
       actionsProcessed++;
       System.out.println(actionsProcessed + "/" + totalActions + " actions processed.");
     }


### PR DESCRIPTION
This modifier is supported on Windows, and allows us to watch the entire file tree recursively.

I've also set up AppVeyor to do builds on Windows: https://ci.appveyor.com/project/gmethvin/directory-watcher/branch/file-tree