### PR TITLE
Handle overflow properly on macOS watcher

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,10 @@ releaseProcess := Seq[ReleaseStep](
 
 def commonSettings = Seq(
   fork in Test := true,
-  javaOptions in Test += "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug",
+  javaOptions in Test ++= Seq(
+    "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug",
+    "-Dio.methvin.watchService.queueSize=16"
+  ),
   libraryDependencies ++= Seq(
     "com.novocode" % "junit-interface" % "0.11" % Test,
     "org.slf4j" % "slf4j-simple" % "1.7.25" % Test,

--- a/core/src/main/java/io/methvin/watchservice/AbstractWatchKey.java
+++ b/core/src/main/java/io/methvin/watchservice/AbstractWatchKey.java
@@ -41,7 +41,9 @@ import static java.util.Objects.requireNonNull;
  */
 class AbstractWatchKey implements WatchKey {
 
-  static final int MAX_QUEUE_SIZE = 256;
+  static final int DEFAULT_QUEUE_SIZE = 1024;
+  static final int QUEUE_SIZE = Integer.parseInt(System.getProperty(
+      "io.methvin.watchService.queueSize", "" + DEFAULT_QUEUE_SIZE));
 
   private static WatchEvent<Object> overflowEvent(int count) {
     return new Event<>(OVERFLOW, count, null);
@@ -55,7 +57,7 @@ class AbstractWatchKey implements WatchKey {
   private final AtomicBoolean valid = new AtomicBoolean(true);
   private final AtomicInteger overflow = new AtomicInteger();
 
-  private final BlockingQueue<WatchEvent<?>> events = new ArrayBlockingQueue<>(MAX_QUEUE_SIZE);
+  private final BlockingQueue<WatchEvent<?>> events = new ArrayBlockingQueue<>(QUEUE_SIZE);
 
   public AbstractWatchKey(
     AbstractWatchService watcher,
@@ -153,7 +155,7 @@ class AbstractWatchKey implements WatchKey {
 
   // WatchEvent not WatchEvent.Kind
   final void signalEvent(WatchEvent.Kind<Path> kind, Path context) {
-    events.add(new Event<>(kind, 1, context));
+    post(new Event<>(kind, 1, context));
     signal();
   }
 }


### PR DESCRIPTION
If we get too many events we should signal the overflow event. 

This also increases the default queue size to 1024 and adds a system property `io.methvin.watchService.queueSize` to customize the queue size.

Fixes #5.