### PR TITLE
Add configuration mechanism for macOS watcher

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,8 +82,7 @@ releaseProcess := Seq[ReleaseStep](
 def commonSettings = Seq(
   fork in Test := true,
   javaOptions in Test ++= Seq(
-    "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug",
-    "-Dio.methvin.watchService.queueSize=16"
+    "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
   ),
   libraryDependencies ++= Seq(
     "com.novocode" % "junit-interface" % "0.11" % Test,

--- a/core/src/main/java/io/methvin/watchservice/AbstractWatchKey.java
+++ b/core/src/main/java/io/methvin/watchservice/AbstractWatchKey.java
@@ -41,10 +41,6 @@ import static java.util.Objects.requireNonNull;
  */
 class AbstractWatchKey implements WatchKey {
 
-  static final int DEFAULT_QUEUE_SIZE = 1024;
-  static final int QUEUE_SIZE = Integer.parseInt(System.getProperty(
-      "io.methvin.watchService.queueSize", "" + DEFAULT_QUEUE_SIZE));
-
   private static WatchEvent<Object> overflowEvent(int count) {
     return new Event<>(OVERFLOW, count, null);
   }
@@ -57,14 +53,17 @@ class AbstractWatchKey implements WatchKey {
   private final AtomicBoolean valid = new AtomicBoolean(true);
   private final AtomicInteger overflow = new AtomicInteger();
 
-  private final BlockingQueue<WatchEvent<?>> events = new ArrayBlockingQueue<>(QUEUE_SIZE);
+  private final BlockingQueue<WatchEvent<?>> events;
 
   public AbstractWatchKey(
     AbstractWatchService watcher,
     @Nullable Watchable watchable,
-    Iterable<? extends WatchEvent.Kind<?>> subscribedTypes) {
+    Iterable<? extends WatchEvent.Kind<?>> subscribedTypes,
+    int queueSize
+  ) {
     this.watcher = requireNonNull(watcher);
     this.watchable = watchable; // nullable for Watcher poison
+    this.events = new ArrayBlockingQueue<>(queueSize);
 
     Set<Kind<?>> types = new HashSet<Kind<?>>();
     subscribedTypes.forEach(types::add);

--- a/core/src/main/java/io/methvin/watchservice/AbstractWatchService.java
+++ b/core/src/main/java/io/methvin/watchservice/AbstractWatchService.java
@@ -42,7 +42,7 @@ import static java.util.Objects.requireNonNull;
 abstract class AbstractWatchService implements WatchService {
 
   private final BlockingQueue<WatchKey> queue = new LinkedBlockingQueue<>();
-  private final WatchKey poison = new AbstractWatchKey(this, null, Collections.emptySet());
+  private final WatchKey poison = new AbstractWatchKey(this, null, Collections.emptySet(), 1);
 
   private final AtomicBoolean open = new AtomicBoolean(true);
 
@@ -51,11 +51,8 @@ abstract class AbstractWatchService implements WatchService {
    * implementation just checks that the service is open and creates a key; subclasses may override
    * it to do other things as well.
    */
-  public AbstractWatchKey register(WatchablePath watchable, Iterable<? extends WatchEvent.Kind<?>> eventTypes)
-    throws IOException {
-    checkOpen();
-    return new AbstractWatchKey(this, watchable, eventTypes);
-  }
+  public abstract AbstractWatchKey register(WatchablePath watchable, Iterable<? extends WatchEvent.Kind<?>> eventTypes)
+    throws IOException;
 
   /**
    * Returns whether or not this watch service is open.

--- a/core/src/main/java/io/methvin/watchservice/MacOSXWatchKey.java
+++ b/core/src/main/java/io/methvin/watchservice/MacOSXWatchKey.java
@@ -24,8 +24,8 @@ class MacOSXWatchKey extends AbstractWatchKey {
   private final boolean reportModifyEvents;
   private final boolean reportDeleteEvents;
 
-  public MacOSXWatchKey(AbstractWatchService macOSXWatchService, Iterable<? extends WatchEvent.Kind<?>> events) {
-    super(macOSXWatchService, null, events);
+  public MacOSXWatchKey(AbstractWatchService macOSXWatchService, Iterable<? extends WatchEvent.Kind<?>> events, int queueSize) {
+    super(macOSXWatchService, null, events, queueSize);
     boolean reportCreateEvents = false;
     boolean reportModifyEvents = false;
     boolean reportDeleteEvents = false;

--- a/core/src/test/java/io/methvin/watchservice/DirectoryWatcherTest.java
+++ b/core/src/test/java/io/methvin/watchservice/DirectoryWatcherTest.java
@@ -43,8 +43,7 @@ public class DirectoryWatcherTest {
     directory.mkdirs();
     MacOSXListeningWatchService service = new MacOSXListeningWatchService();
     MacOSXWatchKey key = new MacOSXWatchKey(service,
-        ImmutableList.of(ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY));
-    // Note: this assumes we set io.methvin.watchService.queueSize to a small enough value
+        ImmutableList.of(ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY), 16);
     int totalEvents = 0;
     for (int i = 0; i < 10; i++) {
       Path toSignal = Paths.get(directory.toPath().toAbsolutePath().toString() + "/" + i);


### PR DESCRIPTION
Now you can pass the `MacOSXListeningWatchService` a `Config` that allows you to configure various things. By using a trait with default methods we can easily add extra parameters in the future without breaking compatibility.