### PR TITLE
Add builder for DirectoryWatcher and pass Logger as parameter

### DIFF
--- a/better-files/src/main/scala/io/methvin/better/files/RecursiveFileMonitor.scala
+++ b/better-files/src/main/scala/io/methvin/better/files/RecursiveFileMonitor.scala
@@ -1,17 +1,31 @@
 package io.methvin.better.files
 
-import java.nio.file.{Path, WatchEvent}
+import java.nio.file.Path
+import java.nio.file.WatchEvent
+import java.util.Collections
 
 import better.files._
+import io.methvin.watcher.DirectoryChangeEvent
 import io.methvin.watcher.DirectoryChangeEvent.EventType
-import io.methvin.watcher.{DirectoryChangeEvent, DirectoryChangeListener, DirectoryWatcher}
+import io.methvin.watcher.DirectoryChangeListener
+import io.methvin.watcher.DirectoryWatcher
+import org.slf4j.Logger
+import org.slf4j.helpers.NOPLogger
 
 import scala.concurrent.ExecutionContext
 
 /**
   * An implementation of the better-files `File.Monitor` interface using directory-watcher.
+  *
+  * @param root the root directory to watch
+  * @param enableFileHashing `true` to hash files to prevent duplicate events, `false` to turn off hashing files.
+  * @param logger the logger used by `DirectoryWatcher`. Useful to see debug output.
   */
-abstract class RecursiveFileMonitor(val root: File) extends File.Monitor {
+abstract class RecursiveFileMonitor(
+  val root: File,
+  val enableFileHashing: Boolean = true,
+  val logger: Logger = NOPLogger.NOP_LOGGER
+) extends File.Monitor {
 
   protected[this] val pathToWatch: Option[Path] =
     if (root.exists) Some(if (root.isDirectory) root.path else root.parent.path) else None
@@ -19,34 +33,38 @@ abstract class RecursiveFileMonitor(val root: File) extends File.Monitor {
   protected[this] def reactTo(path: Path): Boolean =
     path == null || root.isDirectory || root.isSamePathAs(path)
 
-  protected[this] val watcher: DirectoryWatcher = DirectoryWatcher.create(
-    pathToWatch.fold(java.util.Collections.emptyList[Path])(java.util.Collections.singletonList),
-    new DirectoryChangeListener {
-      override def onEvent(event: DirectoryChangeEvent): Unit = {
-        if (reactTo(event.path)) {
-          val et = event.eventType
-          et match {
-            case EventType.OVERFLOW =>
-              onUnknownEvent(new WatchEvent[AnyRef] {
-                override def kind = et.getWatchEventKind.asInstanceOf[WatchEvent.Kind[AnyRef]]
-                override def count = event.count
-                override def context = null
-              })
-            case _ =>
-              RecursiveFileMonitor.this.onEvent(
-                et.getWatchEventKind.asInstanceOf[WatchEvent.Kind[Path]],
-                File(event.path),
-                event.count
-              )
+  protected[this] val watcher: DirectoryWatcher = DirectoryWatcher.builder
+    .paths(pathToWatch.fold(Collections.emptyList[Path]())(Collections.singletonList))
+    .listener(
+      new DirectoryChangeListener {
+        override def onEvent(event: DirectoryChangeEvent): Unit = {
+          if (reactTo(event.path)) {
+            val et = event.eventType
+            et match {
+              case EventType.OVERFLOW =>
+                onUnknownEvent(new WatchEvent[AnyRef] {
+                  override def kind = et.getWatchEventKind.asInstanceOf[WatchEvent.Kind[AnyRef]]
+                  override def count = event.count
+                  override def context = null
+                })
+              case _ =>
+                RecursiveFileMonitor.this.onEvent(
+                  et.getWatchEventKind.asInstanceOf[WatchEvent.Kind[Path]],
+                  File(event.path),
+                  event.count
+                )
+            }
           }
         }
-      }
 
-      override def onException(e: Exception): Unit = {
-        RecursiveFileMonitor.this.onException(e)
+        override def onException(e: Exception): Unit = {
+          RecursiveFileMonitor.this.onException(e)
+        }
       }
-    }
-  )
+    )
+    .fileHashing(enableFileHashing)
+    .logger(logger)
+    .build()
 
   override def start()(implicit executionContext: ExecutionContext): Unit = {
     executionContext.execute(() => watcher.watch())

--- a/core/src/main/java/io/methvin/watcher/DirectoryChangeListener.java
+++ b/core/src/main/java/io/methvin/watcher/DirectoryChangeListener.java
@@ -15,17 +15,25 @@ package io.methvin.watcher;
 
 import java.io.IOException;
 
+/**
+ * A listener that is called when file change events occur or when exceptions occur while watching.
+ */
 @FunctionalInterface
 public interface DirectoryChangeListener {
 
   void onEvent(DirectoryChangeEvent event) throws IOException;
 
+  /**
+   * The watcher will stop watching after this method returns false.
+   */
   default boolean isWatching() {
     return true;
   }
 
-  // A handler for uncaught exceptions. This can rethrow the exception to terminate the watcher.
+  /**
+   * A handler for uncaught exceptions. Throwing an exception from here will terminate the watcher.
+   */
   default void onException(Exception e) {
-    DirectoryWatcher.logger.debug("Got exception while watching", e);
+    // Ignore exceptions by default (they will be logged by the watcher)
   }
 }

--- a/core/src/main/java/io/methvin/watcher/PathUtils.java
+++ b/core/src/main/java/io/methvin/watcher/PathUtils.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
+import java.security.MessageDigest;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;

--- a/core/src/test/java/io/methvin/watchservice/DirectoryWatcherOnDiskTest.java
+++ b/core/src/test/java/io/methvin/watchservice/DirectoryWatcherOnDiskTest.java
@@ -47,14 +47,14 @@ public class DirectoryWatcherOnDiskTest {
 
   @Test
   public void copySubDirectoryFromOutsideNoHashing() throws IOException, ExecutionException, InterruptedException {
-    this.watcher = DirectoryWatcher.create(Collections.singletonList(this.tmpDir), this.recorder, false);
+    this.watcher = DirectoryWatcher.builder().path(this.tmpDir).listener(this.recorder).fileHashing(false).build();
     copySubDirectoryFromOutside();
     this.watcher.close();
   }
 
   @Test
   public void copySubDirectoryFromOutsideWithHashing() throws IOException, ExecutionException, InterruptedException {
-    this.watcher = DirectoryWatcher.create(Collections.singletonList(this.tmpDir), this.recorder, true);
+    this.watcher = DirectoryWatcher.builder().path(this.tmpDir).listener(this.recorder).fileHashing(true).build();
     copySubDirectoryFromOutside();
     this.watcher.close();
   }
@@ -91,14 +91,14 @@ public class DirectoryWatcherOnDiskTest {
 
   @Test
   public void moveSubDirectoryNoHashing() throws IOException, ExecutionException, InterruptedException {
-    this.watcher = DirectoryWatcher.create(Collections.singletonList(this.tmpDir), this.recorder, false);
+    this.watcher = DirectoryWatcher.builder().path(this.tmpDir).listener(this.recorder).fileHashing(false).build();
     moveSubDirectory();
     this.watcher.close();
   }
 
   @Test
   public void moveSubDirectoryWithHashing() throws IOException, ExecutionException, InterruptedException {
-    this.watcher = DirectoryWatcher.create(Collections.singletonList(this.tmpDir), this.recorder, true);
+    this.watcher = DirectoryWatcher.builder().path(this.tmpDir).listener(this.recorder).fileHashing(true).build();
     moveSubDirectory();
     this.watcher.close();
   }
@@ -143,7 +143,7 @@ public class DirectoryWatcherOnDiskTest {
   public void emitCreateEventWhenFileLockedNoHashing() throws IOException, ExecutionException, InterruptedException {
     Assume.assumeTrue(System.getProperty("os.name").toLowerCase().contains("win"));
 
-    this.watcher = DirectoryWatcher.create(Collections.singletonList(this.tmpDir), this.recorder, false);
+    this.watcher = DirectoryWatcher.builder().path(this.tmpDir).listener(this.recorder).fileHashing(false).build();
     final CompletableFuture future = this.watcher.watchAsync();
     Random random = new Random();
     int i = random.nextInt(100_000);
@@ -183,7 +183,7 @@ public class DirectoryWatcherOnDiskTest {
   @Test
   public void doNotEmitCreateEventWhenFileLockedWithHashing() throws IOException, ExecutionException, InterruptedException {
     Assume.assumeTrue(System.getProperty("os.name").toLowerCase().contains("win"));
-    this.watcher = DirectoryWatcher.create(Collections.singletonList(this.tmpDir), this.recorder, true);
+    this.watcher = DirectoryWatcher.builder().path(this.tmpDir).listener(this.recorder).fileHashing(true).build();
     final CompletableFuture future = this.watcher.watchAsync();
     Random random = new Random();
     int i = random.nextInt(100_000);

--- a/core/src/test/java/io/methvin/watchservice/DirectoryWatcherTest.java
+++ b/core/src/test/java/io/methvin/watchservice/DirectoryWatcherTest.java
@@ -148,7 +148,12 @@ public class DirectoryWatcherTest {
     List<FileSystemAction> actions = fileSystem.actions();
 
     TestDirectoryChangeListener listener = new TestDirectoryChangeListener(directory, actions);
-    DirectoryWatcher watcher = new DirectoryWatcher(Collections.singletonList(directory), listener, watchService, true);
+    DirectoryWatcher watcher = DirectoryWatcher.builder()
+        .path(directory)
+        .listener(listener)
+        .watchService(watchService)
+        .fileHashing(true)
+        .build();
     // Fire up the filesystem watcher
     CompletableFuture<Void> future = watcher.watchAsync();
     // Play our filesystem events


### PR DESCRIPTION
Fixes #12. Since there are a lot of parameters now I decided to switch to a builder pattern for creating the `DirectoryWatcher`.

The default logger when using the builder is still `LoggerFactory.getLogger(DirectoryWatcher.class)` but I'm considering maybe using a `NOPLogger` by default and providing an easy way to configure the static logger if you want. Open to change it based on feedback.

I also updated the better-files watcher to allow configuring file hashing and the logger.