### PR TITLE
Support watching independent files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A directory watcher utility for JDK 8+ that aims to provide accurate and efficient recursive watching for Linux, macOS and Windows. In particular, this library provides a JNA-based `WatchService` for Mac OS X to replace the default polling-based JDK implementation.
 
+`directory-watcher` can watch both directories and independent-files.
+
 The core directory-watcher library is designed to have minimal dependencies; currently it only depends on `slf4j-api` (for internal logging, which can be disabled by passing a `NOPLogger` in the builder) and `jna` (for the macOS watcher implementation).
 
 ## Getting started
@@ -61,6 +63,7 @@ public class DirectoryWatchingUtility {
             case DELETE: /* file deleted */; break;
           }
         })
+        // .files(independentFilesToWatch)
         // .fileHashing(false) // defaults to true
         // .logger(logger) // defaults to LoggerFactory.getLogger(DirectoryWatcher.class)
         // .watchService(watchService) // defaults based on OS to either JVM WatchService or the JNA macOS WatchService

--- a/core/src/main/java/io/methvin/watcher/PathUtils.java
+++ b/core/src/main/java/io/methvin/watcher/PathUtils.java
@@ -46,6 +46,10 @@ public class PathUtils {
     return new ConcurrentHashMap<>();
   }
 
+  public static Set<Path> createKeyRootsSet() {
+    return ConcurrentHashMap.newKeySet();
+  }
+
   public static Map<Path, HashCode> createHashCodeMap(Path file, FileHasher fileHasher) {
     return createHashCodeMap(Collections.singletonList(file), fileHasher);
   }
@@ -63,6 +67,22 @@ public class PathUtils {
       }
     }
     return lastModifiedMap;
+  }
+
+  public static Set<Path> nonRecursiveListFiles(Path file) {
+    Set<Path> files = new HashSet<Path>();
+    files.add(file);
+    if (file.toFile().isDirectory()) {
+      File[] filesInDirectory = file.toFile().listFiles();
+      if (filesInDirectory != null) {
+        for (File child : filesInDirectory) {
+          if (!child.isDirectory()) {
+            files.add(child.toPath());
+          }
+        }
+      }
+    }
+    return files;
   }
 
   public static Set<Path> recursiveListFiles(Path file) {

--- a/core/src/main/java/io/methvin/watchservice/WatchablePath.java
+++ b/core/src/main/java/io/methvin/watchservice/WatchablePath.java
@@ -25,16 +25,22 @@ import java.util.Arrays;
 public class WatchablePath implements Watchable {
 
   private final Path file;
+  private final boolean isRecursive;
 
-  public WatchablePath(Path file) {
+  public WatchablePath(Path file, boolean isRecursive) {
     if (file == null) {
       throw new NullPointerException("file must not be null");
     }
     this.file = file;
+    this.isRecursive = isRecursive;
   }
 
   public Path getFile() {
     return file;
+  }
+
+  public boolean isRecursive() {
+    return this.isRecursive;
   }
 
   @Override

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.2
+sbt.version=1.2.1


### PR DESCRIPTION
As explained in the docs, JDK's watch service cannot watch independent
files and instead can only watch directories. To simulate watching
independent files, we watch their parent directories in a non-recursive
manner. This PR implements the bits to simulate this behaviour.

The strategy here is to first register all the paths that are
non-recursive, and then proceed to the recursive ones. If any of the
directories that must be watched non-recursively are subsumed by any of the
recursive directories, they automatically become recursive.

All events about directories contained in non-recursive directories are
ignored by default.