### PR TITLE
Pass file hasher to Mac watch service, and add a last modified hasher

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 version: '{build}'
-os: Windows Server 2012
+os: Visual Studio 2017
 environment:
   JAVA_OPTS: -Dfile.encoding=UTF8
   SBT_OPTS: -Dfile.encoding=UTF8

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,13 @@ matrix:
   include:
     - jdk: oraclejdk8
       language: scala
+    - jdk: oraclejdk11
+      language: scala
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode9.3
+      language: java
+    - os: osx
+      osx_image: xcode10.1
       language: java
 
 cache:

--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ DirectoryWatcher watcher = DirectoryWatcher.builder()
     .path(path)
     .listener(listener)
     // use the last modified time as a "hash" to determine if the file has changed
-    .fileHasher(path -> HashCode.fromLong(Files.getLastModifiedTime(path).toMillis()))
+    .fileHasher(FileHasher.LAST_MODIFIED_TIME)
     .build();
 ```
 
-(Note that simply using the last modified time may not be precise enough for all situations, so could result in missed modify events, but will usually be faster than hashing actual file contents.)
+In the above example we use the last modified time hasher. This hasher is only suitable for platforms that have at least millisecond precision in last modified times from Java. It's known to work with JDK 10+ on Macs with APFS.
 
 ## better-files integration (Scala)
 

--- a/better-files/src/test/scala/io/methvin/better/files/RecursiveFileMonitorSpec.scala
+++ b/better-files/src/test/scala/io/methvin/better/files/RecursiveFileMonitorSpec.scala
@@ -1,6 +1,7 @@
 package io.methvin.better.files
 
 import better.files._
+import io.methvin.watcher.hashing.FileHasher
 import org.scalatest._
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
+++ b/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
@@ -120,8 +120,18 @@ public class DirectoryWatcher {
 
     private Builder osDefaultWatchService() throws IOException {
       boolean isMac = System.getProperty("os.name").toLowerCase().contains("mac");
-      return watchService(
-          isMac ? new MacOSXListeningWatchService() : FileSystems.getDefault().newWatchService());
+      if (isMac) {
+        return watchService(
+            new MacOSXListeningWatchService(
+                new MacOSXListeningWatchService.Config() {
+                  @Override
+                  public FileHasher fileHasher() {
+                    return fileHasher;
+                  }
+                }));
+      } else {
+        return watchService(FileSystems.getDefault().newWatchService());
+      }
     }
 
     private Builder staticLogger() {

--- a/core/src/main/java/io/methvin/watcher/hashing/HashCode.java
+++ b/core/src/main/java/io/methvin/watcher/hashing/HashCode.java
@@ -35,7 +35,7 @@ public class HashCode {
     return new HashCode(new byte[0]);
   }
 
-  private HashCode(byte[] value) {
+  HashCode(byte[] value) {
     this.value = value;
   }
 


### PR DESCRIPTION
Currently since we're not passing the hasher, if you configure a custom hasher it will only be used by the top-level watcher, not by the Mac service.

This also adds a last modified hasher, which is suitable for certain use cases on platforms that provide precise modify times.