### PR TITLE
Option for macOS watcher to use file-level notifications

### DIFF
--- a/core/src/main/java/io/methvin/watcher/PathUtils.java
+++ b/core/src/main/java/io/methvin/watcher/PathUtils.java
@@ -66,7 +66,10 @@ public class PathUtils {
   }
 
   public static Set<Path> recursiveListFiles(Path file) {
-    Set<Path> files = new HashSet<Path>();
+    if (!Files.exists(file)) {
+      return Collections.emptySet();
+    }
+    Set<Path> files = new HashSet<>();
     files.add(file);
     if (file.toFile().isDirectory()) {
       File[] filesInDirectory = file.toFile().listFiles();

--- a/core/src/test/java/io/methvin/watchservice/DirectoryWatcherOnDiskTest.java
+++ b/core/src/test/java/io/methvin/watchservice/DirectoryWatcherOnDiskTest.java
@@ -226,8 +226,7 @@ public class DirectoryWatcherOnDiskTest {
   @Test
   public void doNotEmitCreateEventWhenFileLockedWithHashing()
       throws IOException, ExecutionException, InterruptedException {
-    // This test confirms our assumption that on Windows we lose the event when the hashed file is
-    // locked.
+    // This test confirms that on Windows we lose the event when the hashed file is locked.
     Assume.assumeTrue(System.getProperty("os.name").toLowerCase().contains("win"));
     this.watcher =
         DirectoryWatcher.builder()


### PR DESCRIPTION
This adds support for file-level notifications to the macOS watcher. The file-level notifications also make it possible to disable the internal file hashing on the macOS watcher, since we now can identify the exact file that changed. So now we allow specifying no hasher for the macOS watcher, and automatically enable file-level notifications when that is the case.

This is relevant to #22 though it doesn't technically fix the issue since it doesn't change the default. I'm thinking about changing the default in a future version.