### PR TITLE
Don't follow symlinks

### DIFF
--- a/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
+++ b/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -245,23 +244,10 @@ public class DirectoryWatcher {
                * Walk the file tree to make sure we send create events for any files that were created.
                */
               if (!isMac) {
-                Files.walkFileTree(
+                PathUtils.recursiveVisitFiles(
                     childPath,
-                    new SimpleFileVisitor<Path>() {
-                      @Override
-                      public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
-                          throws IOException {
-                        notifyCreateEvent(dir, count);
-                        return FileVisitResult.CONTINUE;
-                      }
-
-                      @Override
-                      public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                          throws IOException {
-                        notifyCreateEvent(file, count);
-                        return FileVisitResult.CONTINUE;
-                      }
-                    });
+                    dir -> notifyCreateEvent(dir, count),
+                    file -> notifyCreateEvent(file, count));
               }
             }
             notifyCreateEvent(childPath, count);
@@ -336,16 +322,7 @@ public class DirectoryWatcher {
       }
     } else {
       // Since FILE_TREE is unsupported, register root directory and sub-directories
-      Files.walkFileTree(
-          start,
-          new SimpleFileVisitor<Path>() {
-            @Override
-            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
-                throws IOException {
-              register(dir, false);
-              return FileVisitResult.CONTINUE;
-            }
-          });
+      PathUtils.recursiveVisitFiles(start, dir -> register(dir, false), file -> {});
     }
   }
 

--- a/core/src/main/java/io/methvin/watchservice/MacOSXListeningWatchService.java
+++ b/core/src/main/java/io/methvin/watchservice/MacOSXListeningWatchService.java
@@ -218,7 +218,13 @@ public class MacOSXListeningWatchService extends AbstractWatchService {
         /*
          * Note: If file-level events are enabled, fileName will be an individual file so we usually won't recurse.
          */
-        final Set<Path> filesOnDisk = PathUtils.recursiveListFiles(new File(fileName).toPath());
+        Path path = new File(fileName).toPath();
+        final Set<Path> filesOnDisk;
+        try {
+          filesOnDisk = PathUtils.recursiveListFiles(path);
+        } catch (IOException e) {
+          throw new IllegalStateException("Could not recursively list files for " + fileName, e);
+        }
         /*
          * We collect and process all actions for each category of created, modified and deleted as it appears a first thread
          * can start while a second thread can get through faster. If we do the collection for each category in a second


### PR DESCRIPTION
The existing code should never follow symlinks. Following symlinks could be added as a feature, but this needs to consider how the built-in recursive watching is implemented. For example, the macOS watcher will not report changes for symlinked directories.

Fixes #28.