### PR TITLE
Path deletion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,8 @@ lazy val `directory-watcher` = (project in file("core"))
       "io.airlift" % "command" % "0.3" % Test,
       "com.google.guava" % "guava" % "27.0-jre" % Test,
       "org.codehaus.plexus" % "plexus-utils" % "3.1.0" % Test,
-      "commons-io" % "commons-io" % "2.6" % Test
+      "commons-io" % "commons-io" % "2.6" % Test,
+      "org.awaitility" % "awaitility" % "3.1.6" % Test
     )
   )
 

--- a/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
+++ b/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
@@ -341,7 +341,7 @@ public class DirectoryWatcher {
   }
 
   private void notifyCreateEvent(Path path, int count) throws IOException {
-    if (fileHasher != null || Files.isDirectory(path)) {
+    if (fileHasher != null && !Files.isDirectory(path)) {
       HashCode newHash = PathUtils.hash(fileHasher, path);
       if (newHash == null) {
         logger.debug("Failed to hash created file [{}]. It may have been deleted.", path);

--- a/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
+++ b/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
@@ -276,7 +276,9 @@ public class DirectoryWatcher {
               listener.onEvent(new DirectoryChangeEvent(EventType.MODIFY, childPath, count));
             }
           } else if (kind == ENTRY_DELETE) {
-            pathHashes.remove(childPath);
+            // we cannot tell if the deletion was on file or folder because path points nowhere
+            // (file/folder was deleted)
+            pathHashes.entrySet().removeIf(e -> e.getKey().startsWith(childPath));
             listener.onEvent(new DirectoryChangeEvent(EventType.DELETE, childPath, count));
           }
         } catch (Exception e) {
@@ -341,7 +343,7 @@ public class DirectoryWatcher {
   }
 
   private void notifyCreateEvent(Path path, int count) throws IOException {
-    if (fileHasher != null && !Files.isDirectory(path)) {
+    if (fileHasher != null || Files.isDirectory(path)) {
       HashCode newHash = PathUtils.hash(fileHasher, path);
       if (newHash == null) {
         logger.debug("Failed to hash created file [{}]. It may have been deleted.", path);


### PR DESCRIPTION
Unfortunately deletion of folder in Java works differently as deletion of folders per 'hand'. The first one triggers ENTRY_DELETE for all the subfolders and children, whereas the latter triggers only one ENTRY_DELETE for the parent folder.
Nevertheless the logic works (I've stopped the test execution, deleted folder structure manually and resumed the test).

I've introduced the awaitility - it speeds up the execution of tests. If you'll like it, we can adapt other tests