### PR TITLE
Always use absolute path in macOS watcher

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ environment:
 install:
   - cmd: choco install sbt -ia "INSTALLDIR=""C:\sbt"""
   - cmd: SET PATH=C:\sbt\bin;%JAVA_HOME%\bin;%PATH%
-  - cmd: SET SBT_OPTS=-Xmx4G -XX:MaxPermSize=1G
+  - cmd: SET SBT_OPTS=-Xmx4G
 build_script:
   - sbt +compile
 test_script:

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ src_managed/
 .idea_modules
 .bloop
 .metals
+metals.sbt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
----
 sudo: false
 os: linux
 language: scala
 
 scala:
-  - 2.13.1
+  - 2.13.2
   - 2.12.10
 
 env:
   - TRAVIS_JDK=8
-  - TRAVIS_JDK=11
+  - TRAVIS_JDK=13
 
 before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
 install: jabba install "adopt@~1.$TRAVIS_JDK.0-0" && jabba use "$_" && java -Xmx32m -version
@@ -21,12 +20,12 @@ matrix:
   include:
     - os: osx
       osx_image: xcode10.1
-      scala: 2.13.1
+      scala: 2.13.2
       env: TRAVIS_JDK=8
     - os: osx
       osx_image: xcode10.1
-      scala: 2.13.1
-      env: TRAVIS_JDK=11
+      scala: 2.13.2
+      env: TRAVIS_JDK=13
 
 cache:
   directories:

--- a/core/src/main/java/io/methvin/watchservice/MacOSXListeningWatchService.java
+++ b/core/src/main/java/io/methvin/watchservice/MacOSXListeningWatchService.java
@@ -118,14 +118,13 @@ public class MacOSXListeningWatchService extends AbstractWatchService {
       WatchablePath watchable, Iterable<? extends WatchEvent.Kind<?>> events) throws IOException {
     checkOpen();
     final MacOSXWatchKey watchKey = new MacOSXWatchKey(this, events, queueSize);
-    final Path file = watchable.getFile();
+    final Path file = watchable.getFile().toAbsolutePath();
     // if we are already watching a parent of this directory, do nothing.
     for (Path watchedPath : pathsWatching) {
       if (file.startsWith(watchedPath)) return watchKey;
     }
     final Map<Path, HashCode> hashCodeMap = PathUtils.createHashCodeMap(file, fileHasher);
-    final String s = file.toFile().getAbsolutePath();
-    final Pointer[] values = {CFStringRef.toCFString(s).getPointer()};
+    final Pointer[] values = {CFStringRef.toCFString(file.toString()).getPointer()};
     final CFArrayRef pathsToWatch =
         CarbonAPI.INSTANCE.CFArrayCreate(null, values, CFIndex.valueOf(1), null);
     final CarbonAPI.FSEventStreamCallback callback =

--- a/core/src/test/java/io/methvin/watchservice/DirectoryWatcherTest.java
+++ b/core/src/test/java/io/methvin/watchservice/DirectoryWatcherTest.java
@@ -68,6 +68,16 @@ public class DirectoryWatcherTest {
   }
 
   @Test
+  public void validateOsxDirectoryWatcherRelativePath() throws Exception {
+    Assume.assumeTrue(System.getProperty("os.name").toLowerCase().contains("mac"));
+
+    File directory = new File(new File("").getAbsolutePath(), "target/directory");
+    FileUtils.deleteDirectory(directory);
+    directory.mkdirs();
+    runWatcher(Paths.get("target/directory"), new MacOSXListeningWatchService());
+  }
+
+  @Test
   public void validateOsxDirectoryWatcherNoHashing() throws Exception {
     Assume.assumeTrue(System.getProperty("os.name").toLowerCase().contains("mac"));
 
@@ -165,7 +175,7 @@ public class DirectoryWatcherTest {
     List<FileSystemAction> actions = fileSystem.actions();
 
     TestDirectoryChangeListener listener =
-        new TestDirectoryChangeListener(directory, actions, fileHashing);
+        new TestDirectoryChangeListener(directory.toAbsolutePath(), actions, fileHashing);
     DirectoryWatcher watcher =
         DirectoryWatcher.builder()
             .path(directory)


### PR DESCRIPTION
Make sure we always convert the path to absolute when we initialize different components of the macOS watch service.

Fixes #49 