### PR TITLE
Update jna version from 5.5 to 5.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val `directory-watcher` = (project in file("core"))
     autoScalaLibrary := false,
     crossPaths := false,
     libraryDependencies ++= Seq(
-      "net.java.dev.jna" % "jna" % "5.5.0",
+      "net.java.dev.jna" % "jna" % "5.6.0",
       "org.slf4j" % "slf4j-api" % "1.7.30",
       "io.airlift" % "command" % "0.3" % Test,
       "com.google.guava" % "guava" % "28.1-jre" % Test,


### PR DESCRIPTION
The bug mentioned in [https://github.com/gmethvin/directory-watcher/issues/52](https://github.com/gmethvin/directory-watcher/issues/52) was fixed in JNA 5.6.

Related issues and PR
- [https://github.com/gmethvin/directory-watcher/issues/52](https://github.com/gmethvin/directory-watcher/issues/52)
- [https://github.com/playframework/playframework/issues/10372](https://github.com/playframework/playframework/issues/10372)
- [https://github.com/java-native-access/jna/pull/1216](https://github.com/java-native-access/jna/pull/1216)
