### PR TITLE
Fix file creation event notification for locked file on Windows

### DIFF
--- a/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
+++ b/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
@@ -346,7 +346,15 @@ public class DirectoryWatcher {
     if (fileHasher != null || Files.isDirectory(path)) {
       HashCode newHash = PathUtils.hash(fileHasher, path);
       if (newHash == null) {
-        logger.debug("Failed to hash created file [{}]. It may have been deleted.", path);
+        // Hashing could fail for locked files on Windows
+        // Skip notification only if we confirm the file does not exist
+        if (Files.notExists(path)) {
+          logger.debug("Failed to hash created file [{}]. It may have been deleted.", path);
+        } else {
+          logger.debug("Failed to hash created file [{}]. It may be locked.", path);
+          logger.debug("{} [{}]", EventType.CREATE, path);
+          listener.onEvent(new DirectoryChangeEvent(EventType.CREATE, path, count));
+        }
         return;
       }
       // Notify for the file create if not already notified

--- a/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
+++ b/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
@@ -355,13 +355,13 @@ public class DirectoryWatcher {
           logger.debug("{} [{}]", EventType.CREATE, path);
           listener.onEvent(new DirectoryChangeEvent(EventType.CREATE, path, count));
         }
-        return;
-      }
-      // Notify for the file create if not already notified
-      if (!pathHashes.containsKey(path)) {
-        logger.debug("{} [{}]", EventType.CREATE, path);
-        listener.onEvent(new DirectoryChangeEvent(EventType.CREATE, path, count));
-        pathHashes.put(path, newHash);
+      } else {
+        // Notify for the file create if not already notified
+        if (!pathHashes.containsKey(path)) {
+          logger.debug("{} [{}]", EventType.CREATE, path);
+          listener.onEvent(new DirectoryChangeEvent(EventType.CREATE, path, count));
+          pathHashes.put(path, newHash);
+        }
       }
     } else {
       logger.debug("{} [{}]", EventType.CREATE, path);

--- a/core/src/test/java/io/methvin/watchservice/DirectoryWatcherOnDiskTest.java
+++ b/core/src/test/java/io/methvin/watchservice/DirectoryWatcherOnDiskTest.java
@@ -322,9 +322,9 @@ public class DirectoryWatcherOnDiskTest {
   }
 
   @Test
-  public void doNotEmitCreateEventWhenFileLockedWithHashing()
+  public void emitCreateEventWhenFileLockedWithHashing()
       throws IOException, ExecutionException, InterruptedException {
-    // This test confirms that on Windows we lose the event when the hashed file is locked.
+    // This test confirms that on Windows we don't lose the event when the hashed file is locked.
     Assume.assumeTrue(System.getProperty("os.name").toLowerCase().contains("win"));
     this.watcher =
         DirectoryWatcher.builder()
@@ -350,7 +350,14 @@ public class DirectoryWatcherOnDiskTest {
         // Expected exception.
       }
 
-      assertEquals("No event for the file creation expected", 0, this.recorder.events.size());
+      assertEquals("Create event for the child file was notified", 1, this.recorder.events.size());
+
+      assertTrue(
+          "Create event for the child file was notified",
+          existsMatch(
+              e ->
+                  e.eventType() == DirectoryChangeEvent.EventType.CREATE
+                      && e.path().getFileName().equals(child.getFileName())));
 
     } finally {
       if (lock != null && channel != null && channel.isOpen()) {


### PR DESCRIPTION
If we were not able to confirm a file was removed, emit the creation
event even if we failed to hash this file.