### PR TITLE
Use SortedMap for hash code map

### DIFF
--- a/core/src/main/java/io/methvin/watcher/PathUtils.java
+++ b/core/src/main/java/io/methvin/watcher/PathUtils.java
@@ -21,6 +21,7 @@ import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 public class PathUtils {
 
@@ -48,9 +49,9 @@ public class PathUtils {
     return createHashCodeMap(Collections.singletonList(file), fileHasher);
   }
 
-  public static Map<Path, HashCode> createHashCodeMap(List<Path> files, FileHasher fileHasher)
+  public static SortedMap<Path, HashCode> createHashCodeMap(List<Path> files, FileHasher fileHasher)
       throws IOException {
-    Map<Path, HashCode> lastModifiedMap = new ConcurrentHashMap<>();
+    SortedMap<Path, HashCode> lastModifiedMap = new ConcurrentSkipListMap<>();
     if (fileHasher != null) {
       for (Path file : files) {
         for (Path child : recursiveListFiles(file)) {

--- a/core/src/test/java/io/methvin/watchservice/DirectoryWatcherOnDiskTest.java
+++ b/core/src/test/java/io/methvin/watchservice/DirectoryWatcherOnDiskTest.java
@@ -445,17 +445,17 @@ public class DirectoryWatcherOnDiskTest {
     this.recorder.events.clear();
 
     FileUtils.deleteDirectory(paths1.get(2).toFile());
-    await().atMost(3, TimeUnit.HOURS).until(() -> recorder.events.size() == 4);
+    await().atMost(3, TimeUnit.SECONDS).until(() -> recorder.events.size() == 4);
     checkEventsMatchContext(p1, p2, p3);
     this.recorder.events.clear();
 
     FileUtils.deleteDirectory(paths2.get(2).toFile());
-    await().atMost(3, TimeUnit.HOURS).until(() -> recorder.events.size() == 4);
+    await().atMost(3, TimeUnit.SECONDS).until(() -> recorder.events.size() == 4);
     checkEventsMatchContext(p1, p2, p3);
     this.recorder.events.clear();
 
     FileUtils.deleteDirectory(paths3.get(2).toFile());
-    await().atMost(3, TimeUnit.HOURS).until(() -> recorder.events.size() == 4);
+    await().atMost(3, TimeUnit.SECONDS).until(() -> recorder.events.size() == 4);
     checkEventsMatchContext(p1, p2, p3);
     this.recorder.events.clear();
 

--- a/core/src/test/java/io/methvin/watchservice/DirectoryWatcherTest.java
+++ b/core/src/test/java/io/methvin/watchservice/DirectoryWatcherTest.java
@@ -267,7 +267,7 @@ public class DirectoryWatcherTest {
       }
       if (!fileHashing
           && event.eventType() == DirectoryChangeEvent.EventType.MODIFY
-          && System.currentTimeMillis() - createTimes.getOrDefault(event.path(), 0L) < 10) {
+          && System.currentTimeMillis() - createTimes.getOrDefault(event.path(), 0L) < 100) {
         /* ignore this event since it's a create paired with a modify, which we allow when file hashing is disabled */
         return;
       }


### PR DESCRIPTION
Use a `ConcurrentSkipListMap` to track file hashes instead of `ConcurrentHashMap`. Since the map is a `SortedMap`, we can easily remove entire subtrees when they are deleted without having to traverse the entire map. Other map operations are now logarithmic time rather than effectively constant time, but I think that's a reasonable tradeoff.