### PR TITLE
Use sorted map in macOS watch service

### DIFF
--- a/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
+++ b/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
@@ -287,10 +287,7 @@ public class DirectoryWatcher {
               onEvent(EventType.DELETE, childPath, count, rootPath);
             } else {
               // hashing is enabled, so we may know other paths that need to be deleted
-              Set<Path> subtreePaths =
-                  pathHashes
-                      .subMap(childPath, Paths.get(childPath.toString(), "" + Character.MAX_VALUE))
-                      .keySet();
+              Set<Path> subtreePaths = PathUtils.subMap(pathHashes, childPath).keySet();
               for (Path path : subtreePaths) {
                 onEvent(EventType.DELETE, path, count, rootPath);
               }

--- a/core/src/main/java/io/methvin/watcher/PathUtils.java
+++ b/core/src/main/java/io/methvin/watcher/PathUtils.java
@@ -44,7 +44,11 @@ public class PathUtils {
     return new ConcurrentHashMap<>();
   }
 
-  public static Map<Path, HashCode> createHashCodeMap(Path file, FileHasher fileHasher)
+  public static <T> SortedMap<Path, T> subMap(SortedMap<Path, T> hashCodeMap, Path treeRoot) {
+    return hashCodeMap.subMap(treeRoot, Paths.get(treeRoot.toString(), "" + Character.MAX_VALUE));
+  }
+
+  public static SortedMap<Path, HashCode> createHashCodeMap(Path file, FileHasher fileHasher)
       throws IOException {
     return createHashCodeMap(Collections.singletonList(file), fileHasher);
   }


### PR DESCRIPTION
Expose the `SortedMap` type to the macOS watcher, and factor out the logic for getting the path submap.