### PR TITLE
Optional onIdle(count) method added

### DIFF
--- a/core/src/main/java/io/methvin/watcher/DirectoryChangeListener.java
+++ b/core/src/main/java/io/methvin/watcher/DirectoryChangeListener.java
@@ -28,6 +28,10 @@ public interface DirectoryChangeListener {
     return true;
   }
 
+  default void onIdle(int count) {
+    // ignore onIdle by default
+  }
+
   /**
    * A handler for uncaught exceptions. Throwing an exception from here will terminate the watcher.
    */

--- a/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
+++ b/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
@@ -27,21 +27,16 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.*;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -126,7 +121,7 @@ public class DirectoryWatcher {
       if (logger == null) {
         staticLogger();
       }
-      return new DirectoryWatcher(paths, listener, watchService, fileHasher, logger, timeout);
+      return new DirectoryWatcher(paths, listener, watchService, fileHasher, logger);
     }
 
     private Builder osDefaultWatchService() throws IOException {
@@ -154,11 +149,6 @@ public class DirectoryWatcher {
     private Builder staticLogger() {
       return logger(LoggerFactory.getLogger(DirectoryWatcher.class));
     }
-
-    public Builder onIdleTimeout(int timeout) {
-      this.timeout = timeout;
-      return this;
-    }
   }
 
   /** Get a new builder for a {@link DirectoryWatcher}. */
@@ -178,10 +168,6 @@ public class DirectoryWatcher {
   // set to null until we check if FILE_TREE is supported
   private Boolean fileTreeSupported = null;
   private FileHasher fileHasher;
-  private int timeout = -1;
-
-  private Timer timer = new Timer("DirectoryWatcherTimer");
-  private OnIdleTimerTask currentOnIdleTimerTask;
 
   private volatile boolean closed;
 
@@ -190,8 +176,7 @@ public class DirectoryWatcher {
       DirectoryChangeListener listener,
       WatchService watchService,
       FileHasher fileHasher,
-      Logger logger,
-      int timeout)
+      Logger logger)
       throws IOException {
     this.closed = false;
     this.registeredPathToRootPath = new HashMap<>();
@@ -203,7 +188,6 @@ public class DirectoryWatcher {
     this.keyRoots = new ConcurrentHashMap<>();
     this.fileHasher = fileHasher;
     this.logger = logger;
-    this.timeout = timeout;
 
     PathUtils.initWatcherState(paths, fileHasher, pathHashes, directories);
 
@@ -242,28 +226,21 @@ public class DirectoryWatcher {
    * is closed.
    */
   public void watch() {
-    final AtomicInteger eventCount = new AtomicInteger(0);
+    int eventCount = 0;
     while (listener.isWatching()) {
       // wait for key to be signalled
       WatchKey key;
       try {
         key = watchService.poll();
         if (key == null) {
-          if (timeout > 0) {
-            currentOnIdleTimerTask = new OnIdleTimerTask(listener, eventCount.get());
-            timer.schedule(currentOnIdleTimerTask, timeout);
-          }
+          listener.onIdle(eventCount);
           key = watchService.take();
         }
       } catch (InterruptedException x) {
         return;
       }
       for (WatchEvent<?> event : key.pollEvents()) {
-        eventCount.incrementAndGet();
-        if (currentOnIdleTimerTask != null && !currentOnIdleTimerTask.isDone) {
-          currentOnIdleTimerTask.cancel();
-        }
-
+        eventCount++;
         try {
           WatchEvent.Kind<?> kind = event.kind();
           // Context for directory entry event is the file name of entry
@@ -458,26 +435,5 @@ public class DirectoryWatcher {
       directories.add(path);
     }
     onEvent(EventType.CREATE, isDirectory, path, count, rootPath);
-  }
-
-  private class OnIdleTimerTask extends TimerTask {
-
-    private boolean isDone = false;
-
-    private int counter;
-
-    private DirectoryChangeListener listener;
-
-    private OnIdleTimerTask(DirectoryChangeListener listener, int counter) {
-      this.listener = listener;
-      this.counter = counter;
-    }
-
-    @Override
-    public void run() {
-      logger.debug("Task performed on: " + new Date() + " with event count " + counter);
-      listener.onIdle(counter);
-      this.isDone = true;
-    }
   }
 }

--- a/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
+++ b/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
@@ -227,12 +227,18 @@ public class DirectoryWatcher {
     while (listener.isWatching()) {
       // wait for key to be signalled
       WatchKey key;
+      int eventCount = 0;
       try {
-        key = watchService.take();
+        key = watchService.poll();
+        if (key == null) {
+          listener.onIdle(eventCount);
+          key = watchService.take();
+        }
       } catch (InterruptedException x) {
         return;
       }
       for (WatchEvent<?> event : key.pollEvents()) {
+        eventCount++;
         try {
           WatchEvent.Kind<?> kind = event.kind();
           // Context for directory entry event is the file name of entry

--- a/core/src/main/java/io/methvin/watcher/OnTimeoutListener.java
+++ b/core/src/main/java/io/methvin/watcher/OnTimeoutListener.java
@@ -14,7 +14,6 @@
 
 package io.methvin.watcher;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -25,9 +24,8 @@ import java.util.function.Consumer;
 public class OnTimeoutListener implements DirectoryChangeListener {
 
   private final int timeoutMillis;
-
-  private ScheduledExecutorService service;
   private final AtomicReference<ScheduledFuture> currentTaskRef = new AtomicReference<>();
+  private ScheduledExecutorService service;
   private Consumer<Integer> consumer;
 
   public OnTimeoutListener(int timeoutMillis) {
@@ -55,12 +53,11 @@ public class OnTimeoutListener implements DirectoryChangeListener {
               oldTask.cancel(false);
             }
             return service.schedule(
-                () ->
-                    (Callable)
-                        () -> {
-                          consumer.accept(count);
-                          return null;
-                        },
+                () -> {
+                  if (consumer != null) {
+                    consumer.accept(count);
+                  }
+                },
                 timeoutMillis,
                 TimeUnit.MILLISECONDS);
           });

--- a/core/src/main/java/io/methvin/watcher/OnTimeoutListener.java
+++ b/core/src/main/java/io/methvin/watcher/OnTimeoutListener.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.methvin.watcher;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public abstract class OnTimeoutListener implements DirectoryChangeListener {
+
+  private final Object lock = new Object() {};
+
+  private final int timeout;
+
+  private ScheduledExecutorService service;
+  private ScheduledFuture currentTask;
+
+  public OnTimeoutListener(int timeout) {
+    this.timeout = timeout;
+
+    if (timeout >= 0) {
+      service = Executors.newSingleThreadScheduledExecutor();
+    }
+  }
+
+  @Override
+  public void onEvent(DirectoryChangeEvent event) {
+    synchronized (lock) {
+      if (timeout >= 0 && currentTask != null) {
+        currentTask.cancel(false);
+        currentTask = null;
+      }
+    }
+  }
+
+  @Override
+  public void onIdle(int count) {
+    synchronized (lock) {
+      if (timeout >= 0) {
+        if (currentTask != null) {
+          currentTask.cancel(false);
+          currentTask = null;
+        }
+        currentTask = service.schedule(() -> onTimeout(count), timeout, TimeUnit.MILLISECONDS);
+      }
+    }
+  }
+
+  public abstract void onTimeout(int count);
+}

--- a/core/src/main/java/io/methvin/watcher/changeset/ChangeSetListener.java
+++ b/core/src/main/java/io/methvin/watcher/changeset/ChangeSetListener.java
@@ -5,86 +5,15 @@ import io.methvin.watcher.DirectoryChangeListener;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 public final class ChangeSetListener implements DirectoryChangeListener {
 
-  private final Object lock = new Object() {};
-
-  private final AtomicLong onIdleTimeout = new AtomicLong(-1);
-
-  private final Timer timer = new Timer();
-
   private Map<Path, ChangeSetBuilder> changeBuilders = new HashMap<>();
 
-  private DelayedPoll delayedPoll;
-
-  private boolean active;
+  private final Object lock = new Object() {};
 
   public ChangeSetListener() {}
-
-  /**
-   * Flushes and returns a shallow copy the current ChangeSet.
-   * This copies over all the entries and resets the internal collector map.
-   *
-   * @return
-   */
-  public Map<Path, ChangeSet> getChangeSet() {
-    Map<Path, ChangeSetBuilder> returnBuilders;
-    synchronized (lock) {
-      returnBuilders = changeBuilders;
-      changeBuilders = new HashMap<>();
-    }
-    return returnBuilders.entrySet().stream()
-                         .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().toChangeSet()));
-  }
-
-  /**
-   * Blocking method that returns the ChangeSet after DirectoryWatcher has been Idle for more the specified timout.
-   * Note this method may only block a single caller, and will throw an exception if a second caller is added
-   * before the existing has returned.
-   * @param timeout
-   * @return
-   */
-  public Map<Path, ChangeSet> takeChange(int timeout) { // TODO add optional filter, will go back into waiting if it is not true
-    synchronized (lock) {
-      if (onIdleTimeout.compareAndSet(-1, timeout)) { // make sure there is not an existing poller
-        if (!active && !changeBuilders.keySet().isEmpty()) {
-          // It's inactive, but there are changes, so schedule the delay.
-          // This is needed as onIdle will not be called to trigger this, unless another file is received.
-          delayedPoll = new DelayedPoll(timeout); // this cannot exist before,
-                                                  // as compareAndSet ensures no previous poller exists
-          timer.schedule(delayedPoll, timeout);
-        }
-        try {
-          wait(); // will be woken up by the DelayedPoll (either scheduled by above or by the onIdle method)
-          return getChangeSet();
-        } catch (InterruptedException e) {
-          throw new RuntimeException("Polling wait was interrupted.", e);
-        }
-      } else {
-        throw new IllegalStateException("Only a single blocking getChangeSetOnIdle may called at any one time.");
-      }
-    }
-  }
-
-  @Override
-  public void onIdle(int count) {
-    synchronized (lock) {
-      active = false;
-      long timeout = onIdleTimeout.get(); // if the value is >= 0 there is a waiting poller
-      if ( timeout == 0) {
-        notify(); // notify instantly
-      } else if (timeout > 0) {
-        // onIdle has to follow a call to onEvent, so any existing timer must have been cancelled and nulled
-        delayedPoll = new DelayedPoll(timeout);
-        timer.schedule(delayedPoll, timeout);
-      } // else do nothing, as there is no polling waiting for a notify
-    }
-  }
 
   @Override
   public void onEvent(DirectoryChangeEvent event) {
@@ -92,7 +21,6 @@ public final class ChangeSetListener implements DirectoryChangeListener {
     Path path = event.path();
 
     synchronized (lock) {
-      active = true;
       // Maintain a ChangeSet per rootPath
       ChangeSetBuilder builder = changeBuilders.get(rootPath);
       if (builder == null) {
@@ -116,28 +44,16 @@ public final class ChangeSetListener implements DirectoryChangeListener {
         case OVERFLOW:
           throw new IllegalStateException("OVERFLOW not yet handled");
       }
-
-      if (delayedPoll != null) {
-        // there is an onIdle timeout waiting, so cancel it
-        delayedPoll.cancel();
-        delayedPoll = null;
-      }
     }
   }
 
-  class DelayedPoll extends TimerTask {
-    private final long timeout;
-
-    public DelayedPoll(long timeout) {
-      this.timeout = timeout;
+  public Map<Path, ChangeSet> getChangeSet() {
+    Map<Path, ChangeSetBuilder> returnBuilders;
+    synchronized (lock) {
+      returnBuilders = changeBuilders;
+      changeBuilders = new HashMap<>();
     }
-
-    @Override public void run() {
-      synchronized (lock) {
-        delayedPoll = null;
-        notify();
-      }
-    }
+    return returnBuilders.entrySet().stream()
+        .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().toChangeSet()));
   }
-
 }

--- a/core/src/main/java/io/methvin/watcher/changeset/ChangeSetListener.java
+++ b/core/src/main/java/io/methvin/watcher/changeset/ChangeSetListener.java
@@ -5,15 +5,86 @@ import io.methvin.watcher.DirectoryChangeListener;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 public final class ChangeSetListener implements DirectoryChangeListener {
 
-  private Map<Path, ChangeSetBuilder> changeBuilders = new HashMap<>();
-
   private final Object lock = new Object() {};
 
+  private final AtomicLong onIdleTimeout = new AtomicLong(-1);
+
+  private final Timer timer = new Timer();
+
+  private Map<Path, ChangeSetBuilder> changeBuilders = new HashMap<>();
+
+  private DelayedPoll delayedPoll;
+
+  private boolean active;
+
   public ChangeSetListener() {}
+
+  /**
+   * Flushes and returns a shallow copy the current ChangeSet.
+   * This copies over all the entries and resets the internal collector map.
+   *
+   * @return
+   */
+  public Map<Path, ChangeSet> getChangeSet() {
+    Map<Path, ChangeSetBuilder> returnBuilders;
+    synchronized (lock) {
+      returnBuilders = changeBuilders;
+      changeBuilders = new HashMap<>();
+    }
+    return returnBuilders.entrySet().stream()
+                         .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().toChangeSet()));
+  }
+
+  /**
+   * Blocking method that returns the ChangeSet after DirectoryWatcher has been Idle for more the specified timout.
+   * Note this method may only block a single caller, and will throw an exception if a second caller is added
+   * before the existing has returned.
+   * @param timeout
+   * @return
+   */
+  public Map<Path, ChangeSet> takeChange(int timeout) { // TODO add optional filter, will go back into waiting if it is not true
+    synchronized (lock) {
+      if (onIdleTimeout.compareAndSet(-1, timeout)) { // make sure there is not an existing poller
+        if (!active && !changeBuilders.keySet().isEmpty()) {
+          // It's inactive, but there are changes, so schedule the delay.
+          // This is needed as onIdle will not be called to trigger this, unless another file is received.
+          delayedPoll = new DelayedPoll(timeout); // this cannot exist before,
+                                                  // as compareAndSet ensures no previous poller exists
+          timer.schedule(delayedPoll, timeout);
+        }
+        try {
+          wait(); // will be woken up by the DelayedPoll (either scheduled by above or by the onIdle method)
+          return getChangeSet();
+        } catch (InterruptedException e) {
+          throw new RuntimeException("Polling wait was interrupted.", e);
+        }
+      } else {
+        throw new IllegalStateException("Only a single blocking getChangeSetOnIdle may called at any one time.");
+      }
+    }
+  }
+
+  @Override
+  public void onIdle(int count) {
+    synchronized (lock) {
+      active = false;
+      long timeout = onIdleTimeout.get(); // if the value is >= 0 there is a waiting poller
+      if ( timeout == 0) {
+        notify(); // notify instantly
+      } else if (timeout > 0) {
+        // onIdle has to follow a call to onEvent, so any existing timer must have been cancelled and nulled
+        delayedPoll = new DelayedPoll(timeout);
+        timer.schedule(delayedPoll, timeout);
+      } // else do nothing, as there is no polling waiting for a notify
+    }
+  }
 
   @Override
   public void onEvent(DirectoryChangeEvent event) {
@@ -21,6 +92,7 @@ public final class ChangeSetListener implements DirectoryChangeListener {
     Path path = event.path();
 
     synchronized (lock) {
+      active = true;
       // Maintain a ChangeSet per rootPath
       ChangeSetBuilder builder = changeBuilders.get(rootPath);
       if (builder == null) {
@@ -44,16 +116,28 @@ public final class ChangeSetListener implements DirectoryChangeListener {
         case OVERFLOW:
           throw new IllegalStateException("OVERFLOW not yet handled");
       }
+
+      if (delayedPoll != null) {
+        // there is an onIdle timeout waiting, so cancel it
+        delayedPoll.cancel();
+        delayedPoll = null;
+      }
     }
   }
 
-  public Map<Path, ChangeSet> getChangeSet() {
-    Map<Path, ChangeSetBuilder> returnBuilders;
-    synchronized (lock) {
-      returnBuilders = changeBuilders;
-      changeBuilders = new HashMap<>();
+  class DelayedPoll extends TimerTask {
+    private final long timeout;
+
+    public DelayedPoll(long timeout) {
+      this.timeout = timeout;
     }
-    return returnBuilders.entrySet().stream()
-        .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().toChangeSet()));
+
+    @Override public void run() {
+      synchronized (lock) {
+        delayedPoll = null;
+        notify();
+      }
+    }
   }
+
 }

--- a/core/src/test/java/io/methvin/watcher/DirectoryWatcherOnIdleTest.java
+++ b/core/src/test/java/io/methvin/watcher/DirectoryWatcherOnIdleTest.java
@@ -16,6 +16,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.Assume;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -40,6 +41,8 @@ public class DirectoryWatcherOnIdleTest {
 
   @Test
   public void testOnIdle() throws IOException {
+    Assume.assumeTrue(!isMac());
+
     Path d1 = this.tmpDir.resolve("idle1");
     Files.createDirectory(d1);
 
@@ -85,6 +88,8 @@ public class DirectoryWatcherOnIdleTest {
 
   @Test
   public void testOnIdleFilesCreationAdded() throws IOException {
+    Assume.assumeTrue(!isMac());
+
     Path d1 = this.tmpDir.resolve("idle2");
     Files.createDirectory(d1);
 
@@ -135,6 +140,8 @@ public class DirectoryWatcherOnIdleTest {
 
   @Test
   public void testOnIdleChangeSet() throws IOException {
+    Assume.assumeTrue(!isMac());
+
     Path d1 = this.tmpDir.resolve("idle3");
     Files.createDirectory(d1);
 

--- a/core/src/test/java/io/methvin/watcher/DirectoryWatcherOnIdleTest.java
+++ b/core/src/test/java/io/methvin/watcher/DirectoryWatcherOnIdleTest.java
@@ -186,14 +186,7 @@ public class DirectoryWatcherOnIdleTest {
     private final OnTimeoutListener onTimeoutListener;
 
     private CompositeListener(int timeout, Consumer<Integer> consumer) {
-      this.onTimeoutListener =
-          new OnTimeoutListener(timeout) {
-
-            @Override
-            public void onTimeout(int count) {
-              consumer.accept(count);
-            }
-          };
+      this.onTimeoutListener = new OnTimeoutListener(timeout).onTimeout(consumer::accept);
     }
 
     @Override

--- a/core/src/test/java/io/methvin/watcher/DirectoryWatcherOnIdleTest.java
+++ b/core/src/test/java/io/methvin/watcher/DirectoryWatcherOnIdleTest.java
@@ -1,0 +1,153 @@
+package io.methvin.watcher;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import io.methvin.watcher.changeset.ChangeSetListener;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DirectoryWatcherOnIdleTest {
+
+  private Path tmpDir;
+  private DirectoryWatcher watcher;
+
+  @Before
+  public void setUp() throws IOException {
+    this.tmpDir = Files.createTempDirectory(null);
+  }
+
+  @After
+  public void tearDown() {
+    try {
+      FileUtils.deleteDirectory(this.tmpDir.toFile());
+    } catch (Exception e) {
+    }
+  }
+
+  private boolean isMac() {
+    return System.getProperty("os.name").toLowerCase().contains("mac");
+  }
+
+  @Test
+  public void testOnIdle() throws IOException {
+    Path d1 = this.tmpDir.resolve("idle1");
+    Files.createDirectory(d1);
+
+    AtomicLong started = new AtomicLong();
+    AtomicLong updated = new AtomicLong();
+    AtomicInteger counter = new AtomicInteger(-1);
+
+    Consumer<Integer> consumer =
+        value -> {
+          updated.set(System.currentTimeMillis() - started.get());
+          counter.set(value);
+
+          try {
+            watcher.close();
+          } catch (IOException e) {
+            e.printStackTrace();
+          }
+        };
+
+    watcher =
+        DirectoryWatcher.builder()
+            .paths(Arrays.asList(d1))
+            .listener(new Composite(consumer))
+            .fileHashing(true)
+            .onIdleTimeout(100)
+            .build();
+
+    started.set(System.currentTimeMillis());
+    watcher.watchAsync();
+
+    doDelay(400);
+    assertTrue(updated.get() > 0 && updated.get() < 200);
+    assertEquals(0, counter.get());
+  }
+
+  @Test
+  public void testOnIdleFilesCreationAdded() throws IOException {
+    Path d1 = this.tmpDir.resolve("idle2");
+    Files.createDirectory(d1);
+
+    AtomicLong started = new AtomicLong();
+    AtomicLong updated = new AtomicLong();
+    AtomicInteger counter = new AtomicInteger(-1);
+    AtomicInteger onIdleCalled = new AtomicInteger(0);
+
+    Consumer<Integer> consumer =
+        value -> {
+          updated.set(System.currentTimeMillis() - started.get());
+          counter.set(value);
+          onIdleCalled.incrementAndGet();
+        };
+
+    watcher =
+        DirectoryWatcher.builder()
+            .paths(Arrays.asList(d1))
+            .listener(new Composite(consumer))
+            .fileHashing(true)
+            .onIdleTimeout(1000)
+            .build();
+
+    started.set(System.currentTimeMillis());
+    watcher.watchAsync();
+
+    Files.createTempFile(d1, "parent1-", ".dat");
+    doDelay(800);
+    Files.createTempFile(d1, "parent2-", ".dat");
+    Files.createTempFile(d1, "parent3-", ".dat");
+    doDelay(1200);
+    Files.createTempFile(d1, "parent4-", ".dat");
+    doDelay(100);
+    Files.createTempFile(d1, "parent5-", ".dat");
+    doDelay(2000);
+    Files.createTempFile(d1, "parent6-", ".dat");
+    doDelay(800);
+    Files.createTempFile(d1, "parent7-", ".dat");
+    doDelay(1100);
+
+    assertEquals(3, onIdleCalled.get());
+    assertEquals(isMac() ? 15 : 7, counter.get());
+    watcher.close();
+  }
+
+  private void doDelay(long timeout) {
+    try {
+      Thread.sleep(timeout);
+    } catch (InterruptedException e) {
+      throw new UncheckedExecutionException(e);
+    }
+  }
+
+  public static class Composite implements DirectoryChangeListener {
+
+    private Consumer<Integer> counter;
+
+    public Composite(Consumer<Integer> counter) {
+      this.counter = counter;
+    }
+
+    @Override
+    public void onEvent(DirectoryChangeEvent event) {}
+
+    @Override
+    public void onIdle(int count) {
+      counter.accept(count);
+    }
+  }
+}


### PR DESCRIPTION
In some cases it's very useful to be able to get a change set after some predefined period, for example, when we use APT and we want to get a list of generated files and we
 know that the whole generation stage usually takes 500ms. In this PR i introduce the simple mechanism that calls an onIdle method  after timeout expired and passes the number of events within 
that timeout.

@mdproctor ^^ 