### PR TITLE
Always use absolute paths

### DIFF
--- a/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
+++ b/core/src/main/java/io/methvin/watcher/DirectoryWatcher.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -198,7 +199,7 @@ public class DirectoryWatcher {
       FileHasher fileHasher,
       FileTreeVisitor fileTreeVisitor,
       Logger logger) {
-    this.paths = paths;
+    this.paths = paths.stream().map(p -> p.toAbsolutePath()).collect(Collectors.toList());
     this.listener = listener;
     this.watchService = watchService;
     this.isMac = watchService instanceof MacOSXListeningWatchService;


### PR DESCRIPTION
We initialize the hash map using the paths as keys, so we want all paths to be absolute to make sure they match the paths returned by the watch service. This might be a fix for #55 