### PR TITLE
Better handle CREATE for already-hashed files

### DIFF
--- a/core/src/test/java/io/methvin/watcher/DirectoryWatcherOnDiskTest.java
+++ b/core/src/test/java/io/methvin/watcher/DirectoryWatcherOnDiskTest.java
@@ -549,7 +549,7 @@ public class DirectoryWatcherOnDiskTest {
     List<Path> paths2 = createStructure2(p2);
     List<Path> paths3 = createStructure2(p3);
 
-    waitRecorderSize(3, 15);
+    waitRecorderSizeAtLeast(3, 15);
 
     checkEventsMatchContext(p1, p2, p3);
     this.recorder.events.clear();


### PR DESCRIPTION
If the file has already been hashed, it's possible we missed a `DELETE` event, either because of an unexpected exception in the event loop, or due to an `OVERFLOW`. In this case, we may receive a `CREATE` event when the file appears to already exist.

Note that we rely on the suppression of `CREATE` when new directories are created: we need to traverse the existing directory to notify `CREATE` for any files that may have existed before we started listening, but some of those files might have been created just after we started listening, leading to duplicate events.

In both of the above situations, we still want to avoid sending a `CREATE`, because the listener already thinks the file exists. If the hash hasn't changed, the listener is already aware of the state of the file, so it should be safe to suppress the `CREATE` event. If the content has changed, then we should send a `MODIFY` to notify the listener that something changed.